### PR TITLE
Allow omission of first and last delimiter

### DIFF
--- a/src/Preferences.java
+++ b/src/Preferences.java
@@ -29,7 +29,7 @@ public class Preferences {
     }
 
     public int getTargetConsole() {
-        return props.getOrInitInt(PREF_TARGET, TARGET_INTERNAL_CONSOLE);
+        return props.getInt(PREF_TARGET, TARGET_INTERNAL_CONSOLE);
     }
 
     public void setTmuxTarget(String target) {
@@ -37,7 +37,7 @@ public class Preferences {
     }
 
     public String getTmuxTarget() {
-        return props.getOrInit(PREF_TMUX_TARGET, "$ipython:ipython.0");
+        return props.getValue(PREF_TMUX_TARGET, "$ipython:ipython.0");
     }
 
     public void setTmuxExecutable(String execPath) {
@@ -45,7 +45,7 @@ public class Preferences {
     }
 
     public String getTmuxExecutable() {
-        return props.getOrInit(PREF_TMUX_EXECPATH, "/usr/bin/tmux");
+        return props.getValue(PREF_TMUX_EXECPATH, "/usr/bin/tmux");
     }
 
     public void setTmuxTempFilename(String fpath) {
@@ -53,7 +53,7 @@ public class Preferences {
     }
 
     public String getTmuxTempFilename() {
-        return props.getOrInit(PREF_TMUX_TEMPFILE, "/tmp/pycharm.cellmode.tmux");
+        return props.getValue(PREF_TMUX_TEMPFILE, "/tmp/pycharm.cellmode.tmux");
     }
 
 

--- a/src/RunCellAction.java
+++ b/src/RunCellAction.java
@@ -27,15 +27,29 @@ public class RunCellAction extends AbstractRunAction {
         int lineDown = searchForDoubleHash(document, caretLineNumber, 1);
 
         //System.out.println("lineUp : " + lineUp + ", lineDown : " + lineDown);
-        if (lineUp != -1 && lineDown != -1) {
-            int start = document.getLineStartOffset(lineUp + 1);
-            int end = document.getLineEndOffset(lineDown - 1);
-            if (end - start > 0) {
-                CharSequence blockText = document.getCharsSequence().subSequence(start, end);
-                //System.out.println("blockText : " + blockText);
-                return new Block(blockText.toString(), lineUp, lineDown);
-            }
+        int start, end;
+        if (lineUp == -1) {
+            // from top
+            start = 0;
+        } else {
+            // from '##'
+            start = document.getLineStartOffset(lineUp + 1);
         }
+
+        if (lineDown == -1) {
+            // to bottom
+            end = document.getLineEndOffset(document.getLineCount() - 1);
+        } else {
+            // to '##'
+            end = document.getLineEndOffset(lineDown - 1);
+        }
+
+        if (end - start > 0) {
+            CharSequence blockText = document.getCharsSequence().subSequence(start, end);
+            //System.out.println("blockText : " + blockText);
+            return new Block(blockText.toString(), lineUp, lineDown);
+        }
+
         return null;
     }
 

--- a/src/RunCellMoveNextAction.java
+++ b/src/RunCellMoveNextAction.java
@@ -10,6 +10,8 @@ public class RunCellMoveNextAction extends RunCellAction {
     }
 
     private static void moveCaretToLineStart(Editor editor, int line) {
+        if (line == 0)
+            return ;
         Document doc = editor.getDocument();
         if (line < doc.getLineCount()) {
             int newOffset = doc.getLineStartOffset(line);


### PR DESCRIPTION
If we want to split a source file into _n_ cells, we need to put just _n - 1_ delimiters. However, pycharm-cellmode required _n + 1_ delimiters to surround each cell.

This commit allows omission of first and last delimiter ('##'), so we don't need to put additional delimiters.
### before this commit

``` python
##
print 'first cell'
##
print 'second cell'
##
print 'third cell (last cell)'
##
```
### after this commit

``` python
print 'first cell'
##
print 'second cell'
##
print 'third cell (last cell)'
```

This commit maintains also backward compatibility, so we don't need to change previously developed python project.
