### PR TITLE
Make delimiter customizable

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -40,7 +40,7 @@
   <actions>
     <!-- Add your actions here -->
       <action id="PythonCellMode.RunCellMoveNext" class="RunCellMoveNextAction" text="Run _Cell And Move To Next"
-              description="Run cell surrounding the curser in interpreter and move to next cell">
+              description="Run cell surrounding the cursor in interpreter and move to next cell">
           <add-to-group group-id="CodeMenu" anchor="after" relative-to-action="UpdateCopyright"/>
           <keyboard-shortcut keymap="$default" first-keystroke="ctrl B"/>
       </action>

--- a/src/AbstractRunAction.java
+++ b/src/AbstractRunAction.java
@@ -6,6 +6,9 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public abstract class AbstractRunAction extends AnAction {
     public static class Block {
         public final String content;
@@ -86,5 +89,36 @@ public abstract class AbstractRunAction extends AnAction {
             }
         }
         return false;
+    }
+
+    /**
+     * Search for delimiter in the direction given (1 to search down, -1 to search up)
+     * @param startLine the line where to start the search
+     * @return the line on which the delimiter was found or -1 if none is found
+     */
+    protected int searchForDelimiter(Document document, int startLine, int direction) {
+        int lineCount = document.getLineCount();
+        CharSequence text = document.getCharsSequence();
+        for (int line = startLine; line >= 0 && line < lineCount; line += direction) {
+            int start = document.getLineStartOffset(line);
+            int end = document.getLineEndOffset(line);
+            if (end - start < 2) {
+                continue;
+            }
+
+            if (matchesDelimiter(text, start, end)) {
+                return line;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Check if the subseq matches the delimiter defined in prefs
+     */
+    protected boolean matchesDelimiter(CharSequence seq, int start, int end) {
+        Pattern pattern = Pattern.compile(prefs.getDelimiterRegexp());
+        Matcher matcher = pattern.matcher(seq.subSequence(start, end));
+        return matcher.matches();
     }
 }

--- a/src/CellModeConfigurable.form
+++ b/src/CellModeConfigurable.form
@@ -15,15 +15,41 @@
         <properties/>
         <border type="none"/>
         <children>
-          <grid id="7fb84" binding="ipythonOptionsPanel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="7aa96" binding="consolePanel" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
               <gridbag weightx="0.0" weighty="0.0"/>
             </constraints>
-            <properties>
-              <enabled value="false"/>
-            </properties>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="11302" class="javax.swing.JRadioButton" binding="sendInternal">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <selected value="true"/>
+                  <text value="Send to internal python console"/>
+                </properties>
+              </component>
+              <component id="c7d58" class="javax.swing.JRadioButton" binding="sendTmux">
+                <constraints>
+                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Send to ipython in tmux"/>
+                </properties>
+              </component>
+            </children>
+          </grid>
+          <grid id="39b90" binding="ipythonOptionsPanel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <gridbag weightx="0.0" weighty="0.0"/>
+            </constraints>
+            <properties/>
             <border type="none"/>
             <children>
               <component id="87b1" class="javax.swing.JTextField" binding="ipythonSessionName">
@@ -34,14 +60,6 @@
                 </constraints>
                 <properties/>
               </component>
-              <component id="58f9d" class="javax.swing.JLabel">
-                <constraints>
-                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <text value="tmux executable path"/>
-                </properties>
-              </component>
               <component id="fc0f7" class="javax.swing.JTextField" binding="tmuxExecPath">
                 <constraints>
                   <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
@@ -50,9 +68,17 @@
                 </constraints>
                 <properties/>
               </component>
-              <component id="2110f" class="javax.swing.JLabel">
+              <component id="58f9d" class="javax.swing.JLabel">
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="tmux executable path"/>
+                </properties>
+              </component>
+              <component id="2110f" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="tmux target ($session:window.pane)"/>
@@ -76,34 +102,33 @@
               </component>
             </children>
           </grid>
-          <component id="59884" class="javax.swing.JLabel">
+          <grid id="46092" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
               <gridbag weightx="0.0" weighty="0.0"/>
             </constraints>
-            <properties>
-              <text value="Target python console"/>
-            </properties>
-          </component>
-          <component id="11302" class="javax.swing.JRadioButton" binding="sendInternal">
-            <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-              <gridbag weightx="0.0" weighty="0.0"/>
-            </constraints>
-            <properties>
-              <selected value="true"/>
-              <text value="Send to internal python console"/>
-            </properties>
-          </component>
-          <component id="c7d58" class="javax.swing.JRadioButton" binding="sendTmux">
-            <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-              <gridbag weightx="0.0" weighty="0.0"/>
-            </constraints>
-            <properties>
-              <text value="Send to ipython in tmux"/>
-            </properties>
-          </component>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="18669" class="javax.swing.JTextField" binding="delimiterRegexp">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                    <preferred-size width="150" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties/>
+              </component>
+              <component id="cb54" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="delimiter regexp"/>
+                </properties>
+              </component>
+            </children>
+          </grid>
         </children>
       </grid>
     </children>

--- a/src/CellModeConfigurable.java
+++ b/src/CellModeConfigurable.java
@@ -1,5 +1,6 @@
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.ui.IdeBorderFactory;
 
 import javax.swing.*;
 
@@ -12,6 +13,8 @@ public class CellModeConfigurable implements Configurable {
     private JPanel targetPanel;
     private JTextField tmuxExecPath;
     private JTextField tmuxTempFilename;
+    private JPanel consolePanel;
+    private JTextField delimiterRegexp;
 
     private final Preferences prefs;
 
@@ -31,6 +34,9 @@ public class CellModeConfigurable implements Configurable {
 
     @Override
     public JComponent createComponent() {
+        delimiterRegexp.setText(prefs.getDelimiterRegexp());
+        consolePanel.setBorder(IdeBorderFactory.createTitledBorder("Target Python Console", false));
+        ipythonOptionsPanel.setBorder(IdeBorderFactory.createTitledBorder("tmux Options", false));
         ipythonSessionName.setText(prefs.getTmuxTarget());
         tmuxExecPath.setText(prefs.getTmuxExecutable());
         tmuxTempFilename.setText(prefs.getTmuxTempFilename());
@@ -54,6 +60,7 @@ public class CellModeConfigurable implements Configurable {
         } else {
             prefs.setTargetConsole(Preferences.TARGET_TMUX);
         }
+        prefs.setDelimiterRegexp(delimiterRegexp.getText());
         //System.out.println("target console : " + prefs.getTargetConsole());
         //System.out.println("tmux exec : " + prefs.getTmuxExecutable() + ", session : " + prefs.getTmuxTarget());
     }

--- a/src/Preferences.java
+++ b/src/Preferences.java
@@ -10,6 +10,7 @@ public class Preferences {
     private final static String PREF_TMUX_TARGET = PREFS_PREFIX + "tmux_target";
     private final static String PREF_TMUX_EXECPATH = PREFS_PREFIX + "tmux_path";
     private final static String PREF_TMUX_TEMPFILE = PREFS_PREFIX + "tmux_tempfile";
+    private final static String PREF_DELIMITER_REGEXP = PREFS_PREFIX + "delimiter regexp";
 
     private final PropertiesComponent props;
 
@@ -18,6 +19,14 @@ public class Preferences {
         // TODO : Should make the config per-project. But how do we get current project from here ?
         this.props = PropertiesComponent.getInstance();
         //props.setValue("")
+    }
+
+    public String getDelimiterRegexp() {
+        return props.getValue(PREF_DELIMITER_REGEXP, "^\\s*##.*");
+    }
+
+    public void setDelimiterRegexp(String regexp) {
+        props.setValue(PREF_DELIMITER_REGEXP, regexp);
     }
 
     public void setTargetConsole(int target) {

--- a/src/RunCellAction.java
+++ b/src/RunCellAction.java
@@ -1,7 +1,5 @@
-import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
-import org.jetbrains.annotations.NotNull;
 
 
 // grepcode.com is a good source to search the intellij API
@@ -23,8 +21,8 @@ public class RunCellAction extends AbstractRunAction {
         int docCaretOffset = editor.getCaretModel().getOffset();
         int caretLineNumber = document.getLineNumber(docCaretOffset);
 
-        int lineUp = searchForDoubleHash(document, caretLineNumber, -1);
-        int lineDown = searchForDoubleHash(document, caretLineNumber, 1);
+        int lineUp = searchForDelimiter(document, caretLineNumber, -1);
+        int lineDown = searchForDelimiter(document, caretLineNumber, 1);
 
         //System.out.println("lineUp : " + lineUp + ", lineDown : " + lineDown);
         int start, end;


### PR DESCRIPTION
If the cell delimiter of pycharm-cellmode is customizable, pycharm-cellmode can recognize the following cell delimiters.
- '# In[_digit_]:': (used in [nbconvert](https://github.com/jupyter/nbconvert) (.ipnb -> .py converter))
- '#%%' or '# %%': (used in [Spyder](https://github.com/spyder-ide/spyder) (python IDE))

This commit add an option in setting page as shown in the following picture and search for user defined regular expression instead of '##' as the cell delimiter.

![setting](https://cloud.githubusercontent.com/assets/9126033/12063867/810aacf0-aff9-11e5-8302-89d980085cb0.png)

The default regular expression of delimiter is '^\s_##._', so  pycharm-cellmode can recognize also '##' as the cell delimiter.
