### PR TITLE
Fix for plugin exception with pycharm 2021.1

### DIFF
--- a/src/PythonCellLineSeparatorProvider.java
+++ b/src/PythonCellLineSeparatorProvider.java
@@ -14,12 +14,15 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 public class PythonCellLineSeparatorProvider implements LineMarkerProvider {
-    private EditorColorsManager colorsManager;
+    private final EditorColorsManager colorsManager;
 
     protected final Preferences prefs = new Preferences();
 
-    public PythonCellLineSeparatorProvider(DaemonCodeAnalyzerSettings daemonSettings, EditorColorsManager colorsManager) {
-        this.colorsManager = colorsManager;
+    private final DaemonCodeAnalyzerSettings daemonSettings;
+
+    public PythonCellLineSeparatorProvider() {
+        this.colorsManager = EditorColorsManager.getInstance();
+        this.daemonSettings = DaemonCodeAnalyzerSettings.getInstance();
     }
 
     @Override
@@ -34,7 +37,7 @@ public class PythonCellLineSeparatorProvider implements LineMarkerProvider {
     }
 
     @Override
-    public void collectSlowLineMarkers(@NotNull List<PsiElement> list, @NotNull Collection<LineMarkerInfo> collection) {
+    public void collectSlowLineMarkers(@NotNull List<? extends PsiElement> list, @NotNull Collection<? super LineMarkerInfo<?>> collection) {
     }
 
     public static int getLineNumber(Pattern pattern, PsiElement element) {


### PR DESCRIPTION
Hi @julienr 

With current version of pycharm 2021.1, this plugin gives exception: 
<details>
  <summary>Exception stack trace !</summary>
<p>

``` Java
   com.intellij.diagnostic.PluginException: Cannot create class PythonCellLineSeparatorProvider (classloader=PluginClassLoader(plugin=PluginDescriptor(name=PyCharm cell mode, id=net.fhtagn.pycharm.cellmode, descriptorPath=plugin.xml, path=~\AppData\Local\JetBrains\Toolbox\apps\IDEA-U\ch-1\211.6085.26.plugins\PythonCellMode.jar, version=1.2.1, package=null), packagePrefix=null, instanceId=213, state=active))
	at com.intellij.serviceContainer.ComponentManagerImpl.instantiateClass(ComponentManagerImpl.kt:763)
	at com.intellij.serviceContainer.ComponentManagerImpl.instantiateClass(ComponentManagerImpl.kt:781)
	at com.intellij.serviceContainer.LazyExtensionInstance.createInstance(LazyExtensionInstance.java:54)
	at com.intellij.serviceContainer.LazyExtensionInstance.getInstance(LazyExtensionInstance.java:43)
	at com.intellij.serviceContainer.BaseKeyedLazyInstance.getInstance(BaseKeyedLazyInstance.java:38)
	at com.intellij.openapi.util.KeyedExtensionCollector.buildExtensionsFromExtensionPoint(KeyedExtensionCollector.java:155)
	at com.intellij.openapi.util.KeyedExtensionCollector.buildExtensions(KeyedExtensionCollector.java:128)
	at com.intellij.lang.LanguageExtension.buildExtensions(LanguageExtension.java:147)
	at com.intellij.lang.LanguageExtension.buildExtensions(LanguageExtension.java:16)
	at com.intellij.openapi.util.KeyedExtensionCollector.forKey(KeyedExtensionCollector.java:109)
	at com.intellij.lang.LanguageExtension.collectAllForLanguage(LanguageExtension.java:125)
	at com.intellij.lang.LanguageExtension.allForLanguage(LanguageExtension.java:116)
	at com.intellij.lang.LanguageExtension.allForLanguageOrAny(LanguageExtension.java:160)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.getMarkerProviders(LineMarkersPass.java:134)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.lambda$doCollectInformation$3(LineMarkersPass.java:79)
	at com.intellij.codeInsight.daemon.impl.Divider.divideInsideAndOutsideInOneRoot(Divider.java:81)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.doCollectInformation(LineMarkersPass.java:77)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:56)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$1(PassExecutorService.java:400)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1096)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:393)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:688)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:634)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:64)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:392)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:368)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:167)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:178)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:366)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:188)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: java.lang.NoSuchMethodException: PythonCellLineSeparatorProvider.<init>()
	at java.base/java.lang.Class.getConstructor0(Class.java:3349)
	at java.base/java.lang.Class.getDeclaredConstructor(Class.java:2553)
	at com.intellij.serviceContainer.ComponentManagerImpl.instantiateClass(ComponentManagerImpl.kt:720)
	... 34 more
```

</p>
</details>

<details>
  <summary>error detail !</summary>

![image](https://user-images.githubusercontent.com/8335298/114090861-99c1c100-98d5-11eb-933e-65901783fcf7.png)

</details>

So I've refactored the code and tested on pycharm 2021.1, it's working fine.

**This will fix two issues** : 
1. https://github.com/julienr/pycharm-cellmode/issues/16
2. https://github.com/julienr/pycharm-cellmode/issues/14  (I'll reconfirm on this, just quickly tested and it's working fine)

Does this change looks good to you?

Thanks!

Attaching the working one.
[PythonCellMode.zip](https://github.com/julienr/pycharm-cellmode/files/6281234/PythonCellMode.zip)
